### PR TITLE
Include select fields into group_by clause

### DIFF
--- a/Classes/Domain/Repository/LoginHistoryRepository.php
+++ b/Classes/Domain/Repository/LoginHistoryRepository.php
@@ -80,7 +80,7 @@ final class LoginHistoryRepository
             ->orderBy('sys_log.tstamp', 'desc')
 
             // Make sure only one login is shown per user
-            ->groupBy('be_users.uid');
+            ->groupBy('be_users.uid', 'sys_log.tstamp', 'sys_log.IP');
 
         if (!static::getBackendUserAuthentication()->isAdmin()) {
             $query->andWhere($queryBuilder->expr()->eq('be_users.admin', 0));


### PR DESCRIPTION
Fix an exception thrown in Login History module with mysql version > 5.7, where sql_mode=only_full_group_by is set by default.

For further information, here is the documentation about this mode and what it means: https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by

Resolves: #52